### PR TITLE
Fix redirect to work with plain node ServerResponse

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -40,7 +40,8 @@ module.exports = function module(moduleOptions) {
           redirect = `/${redirect}`; // guarantee absolute redirect
         }
 
-        res.redirect(301, redirect);
+        res.writeHead(301, { location: redirect });
+        res.end();
       } else {
         next();
       }


### PR DESCRIPTION
The module crashes with **res.redirect is not a function** in this line:

```js
  this.addServerMiddleware((req, res, next) => {
...
        res.redirect(301, redirect); // <---------------
```

`res` there is an object of type `ServerResponse`, which doesn't have `redirect` method indeed: https://nodejs.org/api/http.html

I guess you only tested it with Express or some other framework which silently extends ServerResponse class.

The PR makes the module compatible with plain node http.