### PR TITLE
Bugfix: Set trailingSlash to false

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -12,7 +12,11 @@ module.exports = function module(moduleOptions) {
     this.options.router = {}
   }
 
-  this.options.router.trailingSlash = false // https://nuxtjs.org/api/configuration-router/#trailingslash
+  /* This is necessary since the documentation at
+  https://nuxtjs.org/api/configuration-router/#trailingslash
+  explains that the router won't accept routes without a trailing slash
+  if this is set to false as it was before */
+  this.options.router.trailingSlash = false
 
   function checkMethods(method) {
     return options.methods.includes(method);

--- a/lib/module.js
+++ b/lib/module.js
@@ -12,7 +12,7 @@ module.exports = function module(moduleOptions) {
     this.options.router = {}
   }
 
-  this.options.router.trailingSlash = true // https://nuxtjs.org/api/configuration-router/#trailingslash
+  this.options.router.trailingSlash = false // https://nuxtjs.org/api/configuration-router/#trailingslash
 
   function checkMethods(method) {
     return options.methods.includes(method);


### PR DESCRIPTION
This is necessary since the documentation at https://nuxtjs.org/api/configuration-router/#trailingslash explains that the router won't accept routes without a trailing slash if this is set to false as it was before.